### PR TITLE
feat: Add anomaly access mapping

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -640,6 +640,18 @@ resource "elasticsearch_opendistro_roles_mapping" "alerting_full_access" {
   backend_roles = ["alerting_full_access"]
 }
 
+resource "elasticsearch_opendistro_roles_mapping" "anomaly_full_access" {
+  role_name     = "anomaly_full_access"
+  description   = "Mapping KC role to ES role"
+  backend_roles = ["anomaly_full_access"]
+}
+
+resource "elasticsearch_opendistro_roles_mapping" "anomaly_read_access" {
+  role_name     = "anomaly_read_access"
+  description   = "Mapping KC role to ES role"
+  backend_roles = ["anomaly_read_access"]
+}
+
 resource "elasticsearch_opendistro_roles_mapping" "all_access" {
   role_name     = "all_access"
   description   = "Mapping KC role to ES role"

--- a/workflow-cli/configuration-keycloak/keycloak-client-roles.json
+++ b/workflow-cli/configuration-keycloak/keycloak-client-roles.json
@@ -21,5 +21,11 @@
   },
   {
     "name": "alerting_full_access"
+  },
+  {
+    "name": "anomaly_full_access"
+  },
+  {
+    "name": "anomaly_read_access"
   }
 ]


### PR DESCRIPTION
Not on the OpenSearch site but the predefined mappings exist there as well.

https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles/#predefined-roles